### PR TITLE
Sanitize each element of an array

### DIFF
--- a/src/yamlinc.js
+++ b/src/yamlinc.js
@@ -363,7 +363,14 @@ module.exports = {
                 data[key] = values(data[key]);
                 continue;
             }
-            data[key] = this.recursiveSanitize(data[key]);
+			
+            if( Array.isArray(data[key]) ) {
+                for( var arrKey in data[key] ) {
+                    data[key][arrKey] = this.recursiveSanitize( data[key][arrKey] );
+                }
+            } else {
+                data[key] = this.recursiveSanitize(data[key]);
+            }
         }
 
         return data;


### PR DESCRIPTION
I spotted a flaw when working with Swagger and using this tool - including within an array context (e.g. Swagger's parameter list) it returns an object rather than an array as it does for objects

**base.yml**
```
object:
  bob:
    type: "string"
    enum:
      $include: "items.yml"
fred:
  - type: "string"
    enum:
      $include: "items.yml"
```

**items.yml**
```
- "item1"
- "item2"
- "item3"
```

**Output**
```
## --------------------
## DON'T EDIT THIS FILE
## --------------------
## Engine: yamlinc@0.0.64
## Source: base.yml

object:
  bob:
    type: string
    enum:
      - item1
      - item2
      - item3
fred:
  - type: string
    enum:
      '0': item1
      '1': item2
      '2': item3
```


With this fix in place:
```
object:
  bob:
    type: string
    enum:
      - item1
      - item2
      - item3
fred:
  - type: string
    enum:
      - item1
      - item2
      - item3
```


My JS foo is a work in progress so there might be a better solution?
