### PR TITLE
Changes helpers.fileExists to use regular stat instead of lstat.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,7 +88,7 @@ module.exports = {
      * @returns {*}
      */
     fileExists: function(file) {
-        return file && fs.existsSync(file) && fs.lstatSync(file).isFile();
+        return file && fs.existsSync(file) && fs.statSync(file).isFile();
     },
 
     /**


### PR DESCRIPTION
This fixes issue #20 -- where you get "file not found" errors when the
target of an `$include` is a symlink to a file. Use of `stat` means the
system will follow these symlinks instead of returning information about
the link itself.