### PR TITLE
Fixes issue with using $include for individual array elements

### DIFF
--- a/src/yamlinc.js
+++ b/src/yamlinc.js
@@ -440,7 +440,7 @@ module.exports = {
      * @returns {RegExp}
      */
     getRegExpIncludeTag: function () {
-        return new RegExp('^[ \\t]*' + this.escapeTag + '[ \\t]*:', 'gmi');
+        return new RegExp('^[- \\t]*' + this.escapeTag + '[- \\t]*:', 'gmi');
     },
 
     /**

--- a/test/samples/sample8-include1.yml
+++ b/test/samples/sample8-include1.yml
@@ -1,0 +1,2 @@
+el: el.a
+prop: el.a prop

--- a/test/samples/sample8-include2.yml
+++ b/test/samples/sample8-include2.yml
@@ -1,0 +1,2 @@
+el: el.b
+prop: el.b prop

--- a/test/samples/sample8-verify.yml
+++ b/test/samples/sample8-verify.yml
@@ -1,0 +1,20 @@
+array1:
+  - el: el.a
+    prop: el.a prop
+  - el: el.b
+    prop: el.b prop
+
+array2:
+  - el: el.a
+    prop: el.a prop
+  - el: el.c
+    prop: el.c prop
+  - el: el.b
+    prop: el.b prop
+
+array3:
+  - el: el.a
+    prop: el.a prop
+    array4:
+      - el: el.b
+        prop: el.b prop

--- a/test/samples/sample8.yml
+++ b/test/samples/sample8.yml
@@ -1,0 +1,14 @@
+array1:
+  - $include: sample8-include1.yml
+  - $include: sample8-include2.yml
+
+array2:
+  - $include: sample8-include1.yml
+  - el: el.c
+    prop: el.c prop
+  - $include: sample8-include2.yml
+
+array3:
+  - $include: sample8-include1.yml
+    array4:
+      - $include: sample8-include2.yml

--- a/test/yamlinc-test.js
+++ b/test/yamlinc-test.js
@@ -59,6 +59,12 @@ describe('Testing Yamlinc', function () {
             );
         });
 
+        it('Include array elements', function () {
+          chai.assert.deepEqual(
+              yamlinc.resolve(__dirname + '/samples/sample8.YML'),
+              yaml.safeLoad(fs.readFileSync(__dirname + '/samples/sample8-verify.yml'))
+          );
+        })
     });
 
     describe('Testing Command-line', function () {


### PR DESCRIPTION
Individual array elements could be included from external files prior to this by formatting the original file like so:

```yaml
array:
  -
    $include: el0.yml
  -
    $include: el1.yml
```

A prettier format like the following would effectively be a no-op b/c the regex for matching the $include tag only allowed for it to be prefixed by white space:
```yaml
array:
  - $include: el0.yml
  - $include: el1.yml
```

This change updates the regex to also allow for the include tag to be prefixed by '-', which allows for the nicer format above to work.