### PR TITLE
Set exact version of package 'colors'

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "chokidar": "^2.0.4",
-        "colors": "^1.3.3",
+        "colors": "1.3.3",
         "cuid": "^2.1.5",
         "deepmerge": "^2.2.1",
         "js-yaml": "^3.13.1",


### PR DESCRIPTION
> The infinite loop introduced in the code (of colors package version 1.4.2) will keep running indefinitely; printing the gibberish non-ASCII character sequence endlessly on the console for any applications that use 'colors.'

More info about colors package issue is here: https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/

Temporary solution is to define exact version of package colors, i.e. 1.3.3 or 1.4.0 instead of ^1.3.3 (which install last minor/patch (compromised) version 1.4.2. This pull requests changes version from `^1.3.3` to `1.3.3`.